### PR TITLE
add more metadata to MLYDownloader

### DIFF
--- a/src/zensvi/download/mapillary/config/api/entities.py
+++ b/src/zensvi/download/mapillary/config/api/entities.py
@@ -638,3 +638,4 @@ class Entities:
 
         # If no error occurred, and all the fields are correct, return the given_fields
         return given_fields
+

--- a/src/zensvi/download/mapillary/controller/image.py
+++ b/src/zensvi/download/mapillary/controller/image.py
@@ -331,7 +331,7 @@ def is_image_being_looked_at_controller(
     return len(result["features"]) != 0
 
 
-def get_image_thumbnail_controller(image_id: str, resolution: int) -> str:
+def get_image_thumbnail_controller(image_id: str, resolution: int, additional_fields=["all"]) -> dict:
     """
     This controller holds the business logic for retrieving
     an image thumbnail with a specific resolution (256, 1024, or 2048)
@@ -344,20 +344,27 @@ def get_image_thumbnail_controller(image_id: str, resolution: int) -> str:
         256, 1024, and 2048
     :type resolution: int
 
-    :return: A URL for the thumbnail
-    :rtype: str
+    :param additional_fields: List of additional fields to include in the result
+    :type additional_fields: list
+
+    :return: A dictionary containing the thumbnail URL and additional fields
+    :rtype: dict
     """
 
     # check if the entered resolution is one of the supported image sizes
     resolution_check(resolution)
-
+    if additional_fields != ["all"]:
+        resolution_field = f"thumb_{resolution}_url"
+        # make sure resolution field is included in the additional fields
+        if resolution_field not in additional_fields:
+            additional_fields.append(resolution_field)
     try:
-        res = Client().get(Entities.get_image(image_id, [f"thumb_{resolution}_url"]))
+        result = Client().get(Entities.get_image(image_id, additional_fields)).json()
     except HTTPError:
         # If given ID is an invalid image ID, let the user know
         raise InvalidImageKeyError(image_id)
-
-    return json.loads(res.content.decode("utf-8"))[f"thumb_{resolution}_url"]
+    
+    return result
 
 
 def get_images_in_bbox_controller(

--- a/src/zensvi/download/mapillary/interface.py
+++ b/src/zensvi/download/mapillary/interface.py
@@ -334,7 +334,7 @@ def get_detections_with_map_feature_id(
 
 
 @auth()
-def image_thumbnail(image_id: str, resolution: int = 1024) -> str:
+def image_thumbnail(image_id: str, resolution: int = 1024, additional_fields=["all"]) -> str:
     """
     Gets the thumbnails of images from the API
 
@@ -355,7 +355,7 @@ def image_thumbnail(image_id: str, resolution: int = 1024) -> str:
         ... )
     """
 
-    return image.get_image_thumbnail_controller(image_id, resolution=resolution)
+    return image.get_image_thumbnail_controller(image_id, resolution, additional_fields)
 
 
 @auth()

--- a/tests/test_mly.py
+++ b/tests/test_mly.py
@@ -3,7 +3,11 @@ import unittest
 import os
 import shutil
 from pathlib import Path
-
+import pandas as pd
+from PIL import Image
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+import cv2
 from zensvi.download.mapillary import interface
 from zensvi.download import MLYDownloader
 
@@ -24,10 +28,10 @@ class TestMapillary(unittest.TestCase):
         self.mly_log = Path(self.mly_output) / "log.log"
         pass
     
-    @classmethod   
-    def tearDown(self):
-        # remove output directory
-        shutil.rmtree(self.mly_output, ignore_errors=True)
+    # @classmethod   
+    # def tearDown(self):
+    #     # remove output directory
+    #     shutil.rmtree(self.mly_output, ignore_errors=True)
 
     # def test_interface(self):
     #     # Skip test if the output file already exists
@@ -96,24 +100,150 @@ class TestMapillary(unittest.TestCase):
     #     # assert True if there are files in the output directory
     #     self.assertTrue(len(os.listdir(self.mly_svi_output_polygon)) > 0)
 
+    def test_downloader_single_field(self):
+        # Set up a new output directory for this test
+        single_field_output = Path(self.mly_output) / "mly_svi_single_field"
+        
+        # Download images with only the 'captured_at' field
+        mly_downloader = MLYDownloader(self.mly_api_key, max_workers=300)
+        mly_downloader.download_svi(
+            single_field_output,
+            input_shp_file=self.mly_input_polygon,
+            additional_fields=["all"]
+        )
+        
+        # Check if the output directory is created and contains files
+        self.assertTrue(single_field_output.exists())
+        self.assertTrue(len(list(single_field_output.glob('**/*'))) > 0)
+        
+        # Check if the mly_pids.csv file exists and contains all the expected columns
+        pids_file = single_field_output / "pids_urls.csv"
+        self.assertTrue(pids_file.exists())
+        
+        df = pd.read_csv(pids_file)
+        
+        # Check for all fields from Entities.get_image_fields()
+        expected_columns = [
+            'altitude', 'atomic_scale', 'camera_parameters', 'camera_type',
+            'captured_at', 'compass_angle', 'computed_altitude',
+            'computed_compass_angle', 'computed_geometry', 'computed_rotation',
+            'exif_orientation', 'geometry', 'height', 'url', 'merge_cc', 'mesh',
+            'quality_score', 'sequence', 'sfm_cluster', 'width'
+        ]
+        
+        for column in expected_columns:
+            self.assertIn(column, df.columns)
+        
+        # Optionally, you can check the content of some image files to ensure they're valid
+        image_files = list(single_field_output.glob('**/*.jpg'))
+        if image_files:
+            with Image.open(image_files[0]) as img:
+                self.assertTrue(img.format in ('JPEG', 'PNG'))
 
-    # test with kwargs for mly
-    def test_downloader_kwargs(self):
-        # Skip test if the output file already exists
-        if os.path.exists(os.path.join(self.mly_svi_output, "mly_svi")):
-            self.skipTest("Result exists")
-        # download images
-        mly_downloader = MLYDownloader(self.mly_api_key, log_path=str(self.mly_log), max_workers=200)
-        kwarg = {
-            "image_type": "flat",  # The tile image_type to be obtained, either as 'flat', 'pano' (panoramic), or 'all'.
-            "min_captured_at": 1484549945000,  # The min date. Format from 'YYYY', to 'YYYY-MM-DDTHH:MM:SS'
-            "max_captured_at": 1642935417694,  # The max date. Format from 'YYYY', to 'YYYY-MM-DDTHH:MM:SS'
-            "organization_id": [1805883732926354],  # The organization id, ID of the organization this image (or sets of images) belong to. It can be absent. Thus, default is -1 (None)
-            "compass_angle": (0,180)
-        }
-        mly_downloader.download_svi(self.mly_svi_output, input_shp_file=self.mly_input_polygon, **kwarg)
-        # assert True if there are files in the output directory
-        self.assertTrue(len(os.listdir(self.mly_svi_output)) > 0)
+    # # test with kwargs for mly
+    # def test_downloader_kwargs(self):
+    #     # Skip test if the output file already exists
+    #     if os.path.exists(os.path.join(self.mly_svi_output, "mly_svi")):
+    #         self.skipTest("Result exists")
+    #     # download images
+    #     mly_downloader = MLYDownloader(self.mly_api_key, log_path=str(self.mly_log), max_workers=200)
+    #     kwarg = {
+    #         "image_type": "flat",  # The tile image_type to be obtained, either as 'flat', 'pano' (panoramic), or 'all'.
+    #         "min_captured_at": 1484549945000,  # The min date. Format from 'YYYY', to 'YYYY-MM-DDTHH:MM:SS'
+    #         "max_captured_at": 1642935417694,  # The max date. Format from 'YYYY', to 'YYYY-MM-DDTHH:MM:SS'
+    #         "organization_id": [1805883732926354],  # The organization id, ID of the organization this image (or sets of images) belong to. It can be absent. Thus, default is -1 (None)
+    #         "compass_angle": (0,180)
+    #     }
+    #     mly_downloader.download_svi(self.mly_svi_output, input_shp_file=self.mly_input_polygon, **kwarg)
+    #     # assert True if there are files in the output directory
+    #     self.assertTrue(len(os.listdir(self.mly_svi_output)) > 0)
+
+    # def test_adjust_image_orientation(self):
+    #     pids_urls_path = Path(self.mly_output) / "mly_svi_single_field" / "pids_urls.csv"
+    #     batch_dirs = [
+    #         Path(self.mly_output) / "mly_svi_single_field" / "mly_svi" / "batch_1",
+    #         Path(self.mly_output) / "mly_svi_single_field" / "mly_svi" / "batch_2"
+    #     ]
+    #     df = pd.read_csv(pids_urls_path)
+        
+    #     def get_camera_matrix_and_dist_coeffs(camera_parameters, camera_type, image_shape):
+    #         params = json.loads(camera_parameters)
+    #         h, w = image_shape[:2]
+            
+    #         focal_length, k1, k2 = params
+    #         cx, cy = w / 2, h / 2  # Assume principal point is at the center
+            
+    #         camera_matrix = np.array([[focal_length, 0, cx],
+    #                                   [0, focal_length, cy],
+    #                                   [0, 0, 1]], dtype=np.float64)
+            
+    #         if camera_type in ["perspective", "fisheye"]:
+    #             dist_coeffs = np.array([k1, k2, 0, 0], dtype=np.float64)
+    #         elif camera_type in ["equirectangular", "spherical"]:
+    #             dist_coeffs = np.zeros(4, dtype=np.float64)
+    #         else:
+    #             raise ValueError(f"Unsupported camera type: {camera_type}")
+            
+    #         return camera_matrix, dist_coeffs
+
+    #     def apply_rotation_to_image(image, rotation_vector, camera_matrix, dist_coeffs, camera_type):
+    #         rotation_matrix, _ = cv2.Rodrigues(rotation_vector)
+    #         h, w = image.shape[:2]
+
+    #         if camera_type == "perspective":
+    #             new_camera_matrix, roi = cv2.getOptimalNewCameraMatrix(camera_matrix, dist_coeffs, (w, h), 1, (w, h))
+    #             undistorted = cv2.undistort(image, camera_matrix, dist_coeffs, None, new_camera_matrix)
+    #             full_transform = new_camera_matrix @ rotation_matrix @ np.linalg.inv(camera_matrix)
+    #             rotated_image = cv2.warpPerspective(undistorted, full_transform, (w, h))
+            
+    #         elif camera_type == "fisheye":
+    #             new_camera_matrix = cv2.fisheye.estimateNewCameraMatrixForUndistortRectify(camera_matrix, dist_coeffs, (w, h), np.eye(3))
+    #             map1, map2 = cv2.fisheye.initUndistortRectifyMap(camera_matrix, dist_coeffs, np.eye(3), new_camera_matrix, (w, h), cv2.CV_16SC2)
+    #             undistorted = cv2.remap(image, map1, map2, interpolation=cv2.INTER_LINEAR, borderMode=cv2.BORDER_CONSTANT)
+    #             full_transform = new_camera_matrix @ rotation_matrix @ np.linalg.inv(camera_matrix)
+    #             rotated_image = cv2.warpPerspective(undistorted, full_transform, (w, h))
+            
+    #         elif camera_type in ["equirectangular", "spherical"]:
+    #             # For equirectangular images, we need to use a different approach
+    #             # This is a simple rotation that might not be perfect for all use cases
+    #             rotated_image = cv2.warpAffine(image, rotation_matrix[:2, :2], (w, h))
+            
+    #         else:
+    #             raise ValueError(f"Unsupported camera type: {camera_type}")
+
+    #         return rotated_image
+
+    #     for _, row in df.iterrows():
+    #         image_id = row['id']
+    #         computed_rotation = row['computed_rotation']
+    #         camera_parameters = row['camera_parameters']
+    #         camera_type = row['camera_type']
+            
+    #         rotation_vector = np.array(json.loads(computed_rotation), dtype=np.float64)
+            
+    #         image_path = None
+    #         for batch_dir in batch_dirs:
+    #             temp_path = batch_dir / f"{image_id}.png"
+    #             if temp_path.exists():
+    #                 image_path = temp_path
+    #                 break
+            
+    #         if image_path is not None:
+    #             image = cv2.imread(str(image_path))
+                
+    #             camera_matrix, dist_coeffs = get_camera_matrix_and_dist_coeffs(camera_parameters, camera_type, image.shape)
+                
+    #             rotated_image = apply_rotation_to_image(image, rotation_vector, camera_matrix, dist_coeffs, camera_type)
+                
+    #             output_path = image_path.with_name(f"{image_id}_rotated.png")
+    #             cv2.imwrite(str(output_path), rotated_image)
+            
+    #             assert output_path.exists()
+
+    #     rotated_images = []
+    #     for batch_dir in batch_dirs:
+    #         rotated_images.extend(list(batch_dir.glob("*_rotated.png")))
+    #     assert len(rotated_images) > 0, "No images were rotated"
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Modified MLYDownloader to download all the available metadata from Mapillary. Users can adjust which metadata to download by changing `additional_fields` argument in `download_svi` function.