### PR TITLE
fix: update GSV tile URL to streetviewpixels endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zensvi"
-version = "1.4.7"
+version = "1.4.8"
 description = "This package handles downloading, cleaning, analyzing street view imagery in a one-stop and zen manner."
 authors = ["koito19960406"]
 license = "MIT"

--- a/src/zensvi/download/utils/imtool.py
+++ b/src/zensvi/download/utils/imtool.py
@@ -70,7 +70,10 @@ class ImageTool:
         while True:
             # Choose a random proxy for each request
             proxy = random.choice(proxies)
-            url_img = f"https://cbk0.google.com/cbk?output=tile&panoid={pano_id}&zoom={zoom}&x={x}&y={y}"
+            url_img = (
+                "https://streetviewpixels-pa.googleapis.com/v1/tile"
+                f"?cb_client=maps_sv.tactile&panoid={pano_id}&x={x}&y={y}&zoom={zoom}"
+            )
             try:
                 image = Image.open(requests.get(url_img, headers=ua, proxies=proxy, stream=True).raw)
                 return image

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -107,6 +107,39 @@ class TestImageTool:
         assert tuple(arr[12, 5, :]) == (0, 0, 255)
 
 
+class TestFetchImageWithProxy:
+    """Tests for ImageTool.fetch_image_with_proxy URL construction."""
+
+    def test_uses_streetviewpixels_endpoint(self, monkeypatch):
+        """Should request the current streetviewpixels tile endpoint with correct params."""
+        from unittest.mock import MagicMock
+
+        captured = {}
+
+        def fake_get(url, **kwargs):
+            captured["url"] = url
+            return MagicMock(raw=MagicMock())
+
+        sentinel = object()
+        monkeypatch.setattr("zensvi.download.utils.imtool.requests.get", fake_get)
+        monkeypatch.setattr("zensvi.download.utils.imtool.Image.open", lambda raw: sentinel)
+
+        result = ImageTool.fetch_image_with_proxy(
+            pano_id="PANO", zoom=2, x=1, y=0, ua={"User-Agent": "test"}, proxies=[{}]
+        )
+
+        assert result is sentinel
+        url = captured["url"]
+        assert url.startswith("https://streetviewpixels-pa.googleapis.com/v1/tile")
+        assert "cb_client=maps_sv.tactile" in url
+        assert "panoid=PANO" in url
+        assert "x=1" in url
+        assert "y=0" in url
+        assert "zoom=2" in url
+        # The deprecated cbk0 endpoint must not be used.
+        assert "cbk0.google.com" not in url
+
+
 class TestCheckAndBuffer:
     """Tests for check_and_buffer function."""
 


### PR DESCRIPTION
## Summary

Google retired the legacy `cbk0.google.com/cbk` Street View tile endpoint (now returns **HTTP 403**), breaking all `GSVDownloader` image downloads. This switches `ImageTool.fetch_image_with_proxy` to the current endpoint:

```
https://streetviewpixels-pa.googleapis.com/v1/tile?cb_client=maps_sv.tactile&panoid={panoid}&x={x}&y={y}&zoom={zoom}
```

This is the only place in the codebase that builds the tile URL.

## Verification

- **Live-checked:** old `cbk0` endpoint → HTTP 403; new endpoint → HTTP 200 with a valid 512×512 tile.
- Added a no-network unit test (`TestFetchImageWithProxy`) asserting the constructed URL.
- Patch version bumped 1.4.7 → 1.4.8.

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)