### PR TITLE
feat: paginate AMS API + default to grid sampling (#157)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zensvi"
-version = "1.6.0"
+version = "1.7.0"
 description = "This package handles downloading, cleaning, analyzing street view imagery in a one-stop and zen manner."
 authors = ["koito19960406"]
 license = "MIT"

--- a/src/zensvi/download/ams.py
+++ b/src/zensvi/download/ams.py
@@ -135,26 +135,41 @@ class AMSDownloader(BaseDownloader):
 
         return results_df
 
-    def _get_raw_pids(self, lat: float, lon: float, buffer: int) -> List[str]:
-        """Get raw panorama IDs from the Amsterdam Street View API."""
-        url = f"https://api.data.amsterdam.nl/panorama/panoramas/?near={lon},{lat}&radius={buffer}&srid=4326"
+    def _get_raw_pids(self, lat: float, lon: float, buffer: int, max_pages: int = 1000) -> List[str]:
+        """Get raw panorama IDs from the Amsterdam Street View API.
 
-        for attempt in range(10):
-            try:
-                proxy = random.choice(self._proxies)
-                user_agent = random.choice(self._user_agents)
-                headers = {"User-Agent": user_agent["user_agent"]}  # Extract the string from the dictionary
-                response = requests.get(url, proxies=proxy, headers=headers)
-                response.raise_for_status()
-                data = json.loads(response.content)
-                panoramas = data["_embedded"]["panoramas"]
-                return [item["pano_id"] for item in panoramas]
-            except Exception as e:
-                if attempt == 9:  # Last attempt
-                    warnings.warn(f"Failed to get panorama IDs after 5 attempts: {e}")
-                    return []
-                print(f"Attempt {attempt + 1} failed: {e}")
-                continue
+        The API returns paginated results (~25 per page), so this follows the
+        ``_links.next`` links to collect every panorama within the radius, not just the
+        first page.
+        """
+        url = f"https://api.data.amsterdam.nl/panorama/panoramas/?near={lon},{lat}&radius={buffer}&srid=4326"
+        pano_ids: List[str] = []
+        pages = 0
+        while url and pages < max_pages:
+            data = None
+            for attempt in range(10):
+                try:
+                    proxy = random.choice(self._proxies)
+                    user_agent = random.choice(self._user_agents)
+                    headers = {"User-Agent": user_agent["user_agent"]}  # Extract the string from the dictionary
+                    response = requests.get(url, proxies=proxy, headers=headers)
+                    response.raise_for_status()
+                    data = json.loads(response.content)
+                    break
+                except Exception as e:
+                    if attempt == 9:  # Last attempt
+                        warnings.warn(f"Failed to get panorama IDs after 10 attempts: {e}")
+                        return pano_ids
+                    print(f"Attempt {attempt + 1} failed: {e}")
+                    continue
+            panoramas = data.get("_embedded", {}).get("panoramas", [])
+            pano_ids.extend(item["pano_id"] for item in panoramas)
+            if not panoramas:
+                break
+            next_link = data.get("_links", {}).get("next")
+            url = next_link.get("href") if isinstance(next_link, dict) else None
+            pages += 1
+        return pano_ids
 
     def _filter_pids_date(
         self, pid_df: pd.DataFrame, start_date: Optional[str], end_date: Optional[str]
@@ -199,8 +214,8 @@ class AMSDownloader(BaseDownloader):
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
         metadata_only: bool = False,
-        grid: bool = False,
-        grid_size: int = 100,
+        grid: bool = True,
+        grid_size: int = 50,
         max_workers: Optional[int] = None,
         verbosity: Optional[int] = None,
     ) -> None:
@@ -232,10 +247,12 @@ class AMSDownloader(BaseDownloader):
                 Format is isoformat (YYYY- MM-DD). Defaults to None.
             metadata_only (bool, optional): Whether to download metadata
                 only. Defaults to False.
-            grid (bool, optional): Grid parameter for the GeoProcessor.
-                Defaults to False.
-            grid_size (int, optional): Grid size parameter for the
-                GeoProcessor. Defaults to 1.
+            grid (bool, optional): Use an equal-distance grid to generate sample
+                points instead of the OSM street network. Defaults to True (faster
+                and avoids the slow, network-dependent Overpass lookup); set False to
+                sample along the street network.
+            grid_size (int, optional): Grid cell size in meters when ``grid`` is True.
+                Defaults to 50.
             max_workers (int, optional): Number of workers for parallel processing.
                 If not specified, uses the value set during initialization.
             verbosity (int, optional): Level of verbosity for progress bars.

--- a/tests/test_ams_pagination.py
+++ b/tests/test_ams_pagination.py
@@ -1,0 +1,59 @@
+"""Fast, no-network tests for AMSDownloader pagination and grid default."""
+
+import inspect
+import json
+
+from zensvi.download.ams import AMSDownloader
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self.content = json.dumps(payload).encode()
+
+    def raise_for_status(self):
+        pass
+
+
+def _downloader():
+    dl = AMSDownloader()
+    # Ensure proxy/user-agent pools are non-empty for random.choice (no network).
+    dl._proxies = [{}]
+    dl._user_agents = [{"user_agent": "test"}]
+    return dl
+
+
+def test_get_raw_pids_paginates(monkeypatch):
+    """_get_raw_pids should follow _links.next and collect every page."""
+    pages = [
+        {
+            "_embedded": {"panoramas": [{"pano_id": "a"}, {"pano_id": "b"}]},
+            "_links": {"next": {"href": "https://api/x?page=2"}},
+        },
+        {"_embedded": {"panoramas": [{"pano_id": "c"}]}, "_links": {"next": None}},
+    ]
+    state = {"i": 0}
+
+    def fake_get(url, **kwargs):
+        resp = _FakeResp(pages[state["i"]])
+        state["i"] += 1
+        return resp
+
+    monkeypatch.setattr("zensvi.download.ams.requests.get", fake_get)
+    ids = _downloader()._get_raw_pids(52.0, 4.0, 50)
+    assert ids == ["a", "b", "c"]
+
+
+def test_get_raw_pids_stops_on_empty_page(monkeypatch):
+    """A page with no panoramas ends pagination even if a next link is present."""
+    monkeypatch.setattr(
+        "zensvi.download.ams.requests.get",
+        lambda url, **kw: _FakeResp({"_embedded": {"panoramas": []}, "_links": {"next": {"href": "x"}}}),
+    )
+    assert _downloader()._get_raw_pids(52.0, 4.0, 50) == []
+
+
+def test_download_svi_defaults_to_grid():
+    """AMS download should default to grid sampling."""
+    sig = inspect.signature(AMSDownloader.download_svi)
+    assert sig.parameters["grid"].default is True
+    assert sig.parameters["grid_size"].default == 50


### PR DESCRIPTION
## Summary

Two changes to `AMSDownloader`, both backed by the grid-vs-OSM benchmark:

1. **Paginate `_get_raw_pids`** — the Amsterdam panorama API returns ~25 results/page with a `_links.next` link; the old code took only the first page. Now follows `next` to collect all pages. **Live-verified: a dense query goes from 25 → 650 panos.** This is the dominant AMS coverage lever.
2. **Default to grid sampling** (`grid=True`, `grid_size=50`) instead of OSM street-network — grid sampling is constant ~3 s vs Overpass's variable 7–83 s, and `street(drive)` only reached 30% recall for AMS at 250 m. `grid=False` stays available.

## Verification (local)
- New `tests/test_ams_pagination.py` (no-network): pagination follows `next`, stops on empty page, and the grid defaults are asserted — **3 passed**.
- Live: `_get_raw_pids` returns 650 panos (was 25) at a dense Amsterdam point.

Minor version bump to **1.7.0**.

> Note: assumes GSV PR #156 (1.6.0) merges first; if merge order differs, only the version line needs adjusting. `pr-checks` gate is satisfied (tests/ changed).

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)